### PR TITLE
using "postmessage" api for sending result (iframe support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.0.1
 
 * Added Support for UPI-Intent in Android Webview
+
+
+## 0.0.2
+
+* Added Support for Iframe Integration
+

--- a/lib/hyper_webview_flutter.dart
+++ b/lib/hyper_webview_flutter.dart
@@ -47,7 +47,27 @@ class HyperWebviewFlutter {
   }
 
   void returnResultInWebview(int requestCode, int resultCode, dynamic result, bool isEncoded){
-    String cmd = "window.onActivityResult('$requestCode' , '$resultCode', '${sanitizeResultdata(result, isEncoded)}')";
+    String sanitizedData = sanitizeResultdata(result, isEncoded);
+    String payload = """
+      JSON.stringify({
+        name: 'onActivityResult',
+        payload: JSON.stringify({
+          requestCode: '$requestCode',
+          resultCode: '$resultCode',
+          data: '$sanitizedData'
+        })
+      })
+    """;
+    String cmd = """
+      try{
+        const message = $payload;
+        window.postMessage(message,"*");
+        const iframes = document.querySelectorAll('iframe');
+        iframes.forEach(function(iframe) {
+          iframe.contentWindow.postMessage(message, '*');
+        });
+      }catch(e){ }
+    """;
     _controller.runJavaScript(cmd);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hyper_webview_flutter
 description: Flutter Library to enhance Juspay's Hyper Checkout Experience for Payment Links opened in WebView.
-version: 0.0.1
+version: 0.0.2
 homepage: https://www.juspay.in
 
 environment:


### PR DESCRIPTION
For clients opening the paymentpage in iframe, the previous approach of calling `window.onActivityResult` to propagate the result won't work. So instead we are now sending the result via the `message` event which works irrespective of whether the client opens payment page in redirection or iframe mode